### PR TITLE
[3기 Wani] TodoList with CRUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,5 +34,7 @@
         </div>
       </main>
     </div>
+
+    <script type='module' src = "js/App.js"></script>
   </body>
 </html>

--- a/js/App.js
+++ b/js/App.js
@@ -1,0 +1,148 @@
+import { $todoItem } from "./Components.js";
+
+let todoList = {
+    todoItems: [],
+    status: 'all'
+}
+
+const init = () => {
+    const localTodoList = JSON.parse(localStorage.getItem('todo'));
+
+    if (localTodoList) {
+        todoList = {
+            ...localTodoList
+        }
+    }
+    const $inputTodo = document.getElementById('new-todo-title');
+    const $AStatusOfActive = document.querySelector('a.active');
+    const $AStatusOfCompleted = document.querySelector('a.completed');
+    const $AStatusOfAll = document.querySelector('a.all');
+    $inputTodo.addEventListener('keyup', handleInputCompleted);
+    $AStatusOfAll.addEventListener('click', handleAClicked);
+    $AStatusOfActive.addEventListener('click', handleAClicked);
+    $AStatusOfCompleted.addEventListener('click', handleAClicked);
+    render(todoList);
+}
+window.addEventListener("load", init);
+
+
+const render = (todoList) => {
+    const $liTodoList = document.getElementById('todo-list');
+    const $inputNewTodoTitle = document.querySelector('#new-todo-title');
+    const $spanTodoListCount = document.querySelector('.todo-count strong');
+    $liTodoList.innerHTML = '';
+    let renderList = [];
+
+    switch (todoList.status) {
+        case 'all' :
+            renderList = todoList.todoItems;
+            break;
+        case 'completed' :
+            renderList = todoList.todoItems.filter(todoItem => todoItem.completed === false);
+            break;
+        case 'active' :
+            renderList = todoList.todoItems.filter(todoItem => todoItem.completed === true);
+            break;
+        default :
+            return;
+
+    }
+
+    renderList.forEach((renderItem, index) => {
+        const $liTodo = document.createElement('li');
+
+
+        $liTodo.innerHTML = $todoItem;
+        $liTodo.dataset.idx = index;
+        $liTodo.setAttribute('class', ({status}) => {
+            if (status === 'editing') return 'editing';
+            if (status === 'completed') return 'completed';
+        });
+        const $labelTodoTitle = $liTodo.querySelector('.label') ;
+        const $inputEdit = $liTodo.querySelector('.edit') ;
+        const $checkBoxToggle = $liTodo.querySelector('.toggle');
+        const $btnDestroy = $liTodo.querySelector('.destroy');
+
+        $inputEdit.value = renderItem.todoTitle;
+        $labelTodoTitle.textContent = renderItem.todoTitle;
+
+        $checkBoxToggle.addEventListener('change' , handleChangeCheckBox);
+        $inputEdit.addEventListener('keyup', handleInputKeyUpInEditing);
+        $btnDestroy.addEventListener('click' , handleClickedDestroy);
+        $liTodo.addEventListener('dblclick' , handleDoubleClick);
+
+        if(renderItem.completed) {
+            $checkBoxToggle.setAttribute('checked' , renderItem.completed);
+        }
+        $liTodoList.append($liTodo);
+    });
+
+    $inputNewTodoTitle.value = '';
+    $spanTodoListCount.textContent = renderList.length;
+    localStorage.setItem('todo' , JSON.stringify(todoList));
+
+}
+
+
+const getLiIndex = ({target}) => {
+    return target.parentNode.parentNode.dataset.idx;
+}
+
+const handleDoubleClick = (e) => {
+    const index = getLiIndex(e);
+    todoList.todoItems[index].editing = true;
+    render(todoList);
+}
+const handleClickedDestroy = (e) => {
+    const index = getLiIndex(e);
+    todoList.todoItems.splice(index, 1);
+    render(todoList);
+}
+
+const handleChangeCheckBox = (e) => {
+    const index = getLiIndex(e);
+    todoList.todoItems[index].completed = e.target.checked;
+    render(todoList);
+}
+
+const handleInputKeyUpInEditing = (e) => {
+    const index = e.target.parentNode.dataset.idx;
+    switch (e.key) {
+        case 'Escape' :
+            todoList.todoItems[index].editing = false;
+            break;
+        case 'Enter' :
+            todoList.todoItems[index] = {...todoList.todoItems[index], todoTitle: e.target.value, editing: false};
+            break;
+        default :
+            return;
+    }
+    render(todoList);
+}
+const handleInputCompleted = (e) => {
+    if (e.key === 'Enter') {
+        const todoItem = {
+            todoTitle: e.target.value,
+            completed: false,
+            editing: false,
+        }
+        todoList.todoItems = [...todoList.todoItems, todoItem];
+        render(todoList)
+    }
+}
+const handleAClicked = (e) => {
+    switch (e.target.className) {
+        case 'all selected' :
+            todoList.status = 'all';
+            break;
+        case 'active' :
+            todoList.status = 'active';
+            break;
+        case 'completed' :
+            todoList.status = 'completed';
+            break;
+        default :
+            break;
+    }
+    render(todoList);
+}

--- a/js/Components.js
+++ b/js/Components.js
@@ -1,0 +1,7 @@
+export const $todoItem = `
+    <div class="view">
+        <input class="toggle" type="checkbox"/>
+        <label class="label">새로운 타이틀</label>
+        <button class="destroy"></button>
+    </div>
+    <input class="edit" value="새로운 타이틀" />`;


### PR DESCRIPTION
요구사항들
todo list에 todoItem을 키보드로 입력하여 추가하기
todo list의 체크박스를 클릭하여 complete 상태로 변경. (li tag 에 completed class 추가, input 태그에 checked 속성 추가)
todo list의 x버튼을 이용해서 해당 엘리먼트를 삭제
todo list를 더블클릭했을 때 input 모드로 변경. (li tag 에 editing class 추가) 단 이때 수정을 완료하지 않은 상태에서 esc키를 누르면 수정되지 않은 채로 다시 view 모드로 복귀
todo list의 item갯수를 count한 갯수를 리스트의 하단에 보여주기
todo list의 상태값을 확인하여, 해야할 일과, 완료한 일을 클릭하면 해당 상태의 아이템만 보여주기
localStorage에 데이터를 저장하여, TodoItem의 CRUD를 반영하기. 따라서 새로고침하여도 저장된 데이터를 확인할 수 있어야 함

느낀점 :
페어프로그래밍을 진행하면서 서로 어떻게 커밋 로그를 남길까 고민을 하다가 마지막날에 각자 다시 손본뒤 PR을 요청하기로 했습니다.
3일동안 페어 프로그래밍을 하면서 다른 사람들의 자바스크립트 꿀팁을 많이 알았고 js로 많은걸 할 수 있다고 느꼈습니다.
특히 다른분들의 코드를 보면서 깔끔한 점에 놀랐고 잘 안되는 부분이 있으면 참고를 많이 했습니다.

아쉬운점:
1. js 기초를 다시 쌓자.
2.다른사람들의 코드를 많이 읽어보자.
