### PR TITLE
[6기 김동환] TodoList with CRUD 

### DIFF
--- a/LocalStorageSupporter.js
+++ b/LocalStorageSupporter.js
@@ -1,0 +1,40 @@
+export class LocalStorageSupporter {
+  constructor(key) {
+    this.key = key;
+  }
+
+  get() {
+    return JSON.parse(localStorage.getItem(this.key)) || [];
+  }
+
+  save(todoItem) {
+    const todoItems = this.get();
+    todoItems.push(todoItem);
+    localStorage.setItem(this.key, JSON.stringify(todoItems));
+  }
+
+  complete(todoItem) {
+    const localTodoItem = this.get();
+    localTodoItem.filter((item) => item.todoItem === todoItem)
+                 .map((item) => (item.completed = !item.completed));
+
+    localStorage.setItem(this.key, JSON.stringify(localTodoItem));
+  }
+
+  delete(todoItem) {
+    const todoItems = this.get();
+    const index = todoItems.findIndex(
+        (item) => item.todoItem === todoItem
+    );
+    todoItems.splice(index, 1);
+    localStorage.setItem(this.key, JSON.stringify(todoItems));
+  }
+
+  update(id, todoItem){
+    const todoItems = this.get();
+    const index = todoItems.findIndex((item) => item.todoItem === id);
+    todoItems[index].todoItem = todoItem;
+    localStorage.setItem(this.key, JSON.stringify(todoItems));
+    return todoItems;
+  }
+}

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 import { TodoApp } from "./component/TodoApp.js"
 
 const $div = document.querySelector('.todoapp')
-const app = new TodoApp($div);
+new TodoApp($div);
     
 
 

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
 import { TodoApp } from "./component/TodoApp.js"
 
 const $div = document.querySelector('.todoapp')
-new TodoApp($div);
+new TodoApp($div).render();

--- a/app.js
+++ b/app.js
@@ -2,6 +2,3 @@ import { TodoApp } from "./component/TodoApp.js"
 
 const $div = document.querySelector('.todoapp')
 new TodoApp($div);
-    
-
-

--- a/app.js
+++ b/app.js
@@ -1,0 +1,7 @@
+import { TodoApp } from "./component/TodoApp.js"
+
+const $div = document.querySelector('.todoapp')
+const app = new TodoApp($div);
+    
+
+

--- a/component/TodoApp.js
+++ b/component/TodoApp.js
@@ -3,10 +3,10 @@ import { TodoInput } from './TodoInput.js';
 import { TodoTotalCount } from './TodoTotalCount.js'
 
 export function TodoApp($div) {
-    const $input = $div.querySelector("#new-todo-title");
     const $ul = $div.querySelector('#todo-list')
 
     this.todoItems = [];
+    this.filter = '전체보기';
 
     this.todoInput = new TodoInput(this);
     this.todoList = new TodoList($ul, this);
@@ -14,8 +14,7 @@ export function TodoApp($div) {
 
     this.saveItem = (item) => {
       this.todoItems.push(item)
-      this.todoList.setState(this.todoItems);
-      this.todoTotalCount.setState(this.todoItems);
+      this.filterTodo(this.filter);
     }
 
     this.complete = (todoItem) => {
@@ -28,7 +27,7 @@ export function TodoApp($div) {
       const index = this.todoItems.findIndex(item => item.todoItem === todoItem);
       this.todoItems.splice(index, 1);
       this.todoList.render(this.todoItems);
-      this.todoTotalCount.setState(this.todoItems);
+      this.todoTotalCount.setState(this.todoItems, this.filter);
     }
 
     this.update = (id, todoItem) =>{
@@ -38,19 +37,19 @@ export function TodoApp($div) {
     }
 
     this.filterTodo = (completeState) =>{
-
-      if(completeState === '전체보기') {
+      this.filter = completeState;
+      if(this.filter === '전체보기') {
         this.todoList.render(this.todoItems);
-        this.todoTotalCount.setState(this.todoItems);
+        this.todoTotalCount.setState(this.todoItems, this.filter);
       }
 
-      if(completeState === '해야할 일'){
+      if(this.filter === '해야할 일'){
         const notCompletedItems =  this.todoItems.filter(item => !item.completed);
         this.todoList.render(notCompletedItems);
         this.todoTotalCount.setState(notCompletedItems);
       }
     
-      if(completeState === '완료한 일'){
+      if(this.filter === '완료한 일'){
         const completedItems =  this.todoItems.filter(item => item.completed);
         this.todoList.render(completedItems);
         this.todoTotalCount.setState(completedItems);
@@ -63,8 +62,7 @@ export function TodoApp($div) {
       TodoList.setState(this.todoItems);
     };
 
-
-
+    
 }
   
 

--- a/component/TodoApp.js
+++ b/component/TodoApp.js
@@ -1,0 +1,70 @@
+import { TodoList } from './TodoList.js';
+import { TodoInput } from './TodoInput.js';
+import { TodoTotalCount } from './TodoTotalCount.js'
+
+export function TodoApp($div) {
+    const $input = $div.querySelector("#new-todo-title");
+    const $ul = $div.querySelector('#todo-list')
+
+    this.todoItems = [];
+
+    this.todoInput = new TodoInput(this);
+    this.todoList = new TodoList($ul, this);
+    this.todoTotalCount = new TodoTotalCount( $div, this );
+
+    this.saveItem = (item) => {
+      this.todoItems.push(item)
+      this.todoList.setState(this.todoItems);
+      this.todoTotalCount.setState(this.todoItems);
+    }
+
+    this.complete = (todoItem) => {
+      this.todoItems.filter(item => item.todoItem === todoItem)
+                    .forEach(item => item.completed = !item.completed)
+      this.todoList.setState(this.todoItems);
+    }
+
+    this.delete = (todoItem) => {
+      const index = this.todoItems.findIndex(item => item.todoItem === todoItem);
+      this.todoItems.splice(index, 1);
+      this.todoList.render(this.todoItems);
+      this.todoTotalCount.setState(this.todoItems);
+    }
+
+    this.update = (id, todoItem) =>{
+      const index = this.todoItems.findIndex(item => item.todoItem === id);
+      this.todoItems[index].todoItem = todoItem;
+      this.todoList.render(this.todoItems)
+    }
+
+    this.filterTodo = (completeState) =>{
+
+      if(completeState === '전체보기') {
+        this.todoList.render(this.todoItems);
+        this.todoTotalCount.setState(this.todoItems);
+      }
+
+      if(completeState === '해야할 일'){
+        const notCompletedItems =  this.todoItems.filter(item => !item.completed);
+        this.todoList.render(notCompletedItems);
+        this.todoTotalCount.setState(notCompletedItems);
+      }
+    
+      if(completeState === '완료한 일'){
+        const completedItems =  this.todoItems.filter(item => item.completed);
+        this.todoList.render(completedItems);
+        this.todoTotalCount.setState(completedItems);
+      }
+    
+
+    }
+    this.setState = updatedItems => {
+      this.todoItems = updatedItems;
+      TodoList.setState(this.todoItems);
+    };
+
+
+
+}
+  
+

--- a/component/TodoApp.js
+++ b/component/TodoApp.js
@@ -6,11 +6,16 @@ export function TodoApp($div) {
     const $ul = $div.querySelector('#todo-list')
 
     this.todoItems = [];
-    this.filter = '전체보기';
+    this.filter = 'all';
 
     this.todoInput = new TodoInput(this);
     this.todoList = new TodoList($ul, this);
     this.todoTotalCount = new TodoTotalCount( $div, this );
+
+    this.setState = updatedItems => {
+      this.todoItems = updatedItems;
+      this.TodoList.setState(this.todoItems);
+    };
 
     this.saveItem = (item) => {
       this.todoItems.push(item)
@@ -18,16 +23,17 @@ export function TodoApp($div) {
     }
 
     this.complete = (todoItem) => {
+      
       this.todoItems.filter(item => item.todoItem === todoItem)
-                    .forEach(item => item.completed = !item.completed)
-      this.todoList.setState(this.todoItems);
+                     .map(item => item.completed = !item.completed)
+
+      this.filterTodo(this.filter);
     }
 
     this.delete = (todoItem) => {
       const index = this.todoItems.findIndex(item => item.todoItem === todoItem);
       this.todoItems.splice(index, 1);
-      this.todoList.render(this.todoItems);
-      this.todoTotalCount.setState(this.todoItems, this.filter);
+      this.filterTodo(this.filter);
     }
 
     this.update = (id, todoItem) =>{
@@ -35,34 +41,20 @@ export function TodoApp($div) {
       this.todoItems[index].todoItem = todoItem;
       this.todoList.render(this.todoItems)
     }
+  
+      this.filterTodo = (completeStatus) =>{
+        this.filter = completeStatus;
+      
+        const status = {
+          all : () => this.todoItems,
+          active : () => this.todoItems.filter(item => !item.completed),
+          completed : () => this.todoItems.filter(item => item.completed)
+        }
+        const filterTodoItems = status[this.filter]();
 
-    this.filterTodo = (completeState) =>{
-      this.filter = completeState;
-      if(this.filter === '전체보기') {
-        this.todoList.render(this.todoItems);
-        this.todoTotalCount.setState(this.todoItems, this.filter);
-      }
-
-      if(this.filter === '해야할 일'){
-        const notCompletedItems =  this.todoItems.filter(item => !item.completed);
-        this.todoList.render(notCompletedItems);
-        this.todoTotalCount.setState(notCompletedItems);
-      }
-    
-      if(this.filter === '완료한 일'){
-        const completedItems =  this.todoItems.filter(item => item.completed);
-        this.todoList.render(completedItems);
-        this.todoTotalCount.setState(completedItems);
-      }
-    
-
+        this.todoList.render(filterTodoItems);
+        this.todoTotalCount.setState(filterTodoItems, this.filter);
     }
-    this.setState = updatedItems => {
-      this.todoItems = updatedItems;
-      TodoList.setState(this.todoItems);
-    };
-
-    
 }
   
 

--- a/component/TodoApp.js
+++ b/component/TodoApp.js
@@ -1,60 +1,55 @@
 import { TodoList } from "./TodoList.js";
 import { TodoInput } from "./TodoInput.js";
 import { TodoTotalCount } from "./TodoTotalCount.js";
+import { LocalStorageSupporter } from '../LocalStorageSupporter.js'
 
 export function TodoApp($div) {
   const $ul = $div.querySelector("#todo-list");
 
-  this.todoItems = [];
+  const storage = new LocalStorageSupporter('todoItem');
+  this.todoItems = storage.get();
   this.filter = "all";
 
   this.todoInput = new TodoInput(this);
   this.todoList = new TodoList($ul, this);
   this.todoTotalCount = new TodoTotalCount($div, this);
 
-  this.setState = (updatedItems) => {
-    this.todoItems = updatedItems;
-    this.TodoList.setState(this.todoItems);
-  };
-
-  this.saveItem = (item) => {
-    this.todoItems.push(item);
+  this.saveItem = (item) => { 
+    storage.save(item);
     this.filterTodo(this.filter);
   };
 
   this.complete = (todoItem) => {
-    this.todoItems
-      .filter((item) => item.todoItem === todoItem)
-      .map((item) => (item.completed = !item.completed));
-
+    storage.complete(todoItem);
     this.filterTodo(this.filter);
   };
 
   this.delete = (todoItem) => {
-    const index = this.todoItems.findIndex(
-      (item) => item.todoItem === todoItem
-    );
-    this.todoItems.splice(index, 1);
+    storage.delete(todoItem);
     this.filterTodo(this.filter);
   };
 
   this.update = (id, todoItem) => {
-    const index = this.todoItems.findIndex((item) => item.todoItem === id);
-    this.todoItems[index].todoItem = todoItem;
-    this.todoList.render(this.todoItems);
+    const updateItems = storage.update(id, todoItem);
+    this.todoList.render(updateItems);
   };
 
   this.filterTodo = (completeStatus) => {
+  
     this.filter = completeStatus;
-
     const status = {
-      all: () => this.todoItems,
-      active: () => this.todoItems.filter((item) => !item.completed),
-      completed: () => this.todoItems.filter((item) => item.completed),
+      all: () => storage.get(),
+      active: () => storage.get().filter((item) => !item.completed),
+      completed: () =>  storage.get().filter((item) => item.completed),
     };
     const filterTodoItems = status[this.filter]();
 
     this.todoList.render(filterTodoItems);
     this.todoTotalCount.setState(filterTodoItems, this.filter);
   };
+
+
+  this.render = () =>{
+    this.todoList.setState(storage.get());
+  }
 }

--- a/component/TodoApp.js
+++ b/component/TodoApp.js
@@ -1,60 +1,60 @@
-import { TodoList } from './TodoList.js';
-import { TodoInput } from './TodoInput.js';
-import { TodoTotalCount } from './TodoTotalCount.js'
+import { TodoList } from "./TodoList.js";
+import { TodoInput } from "./TodoInput.js";
+import { TodoTotalCount } from "./TodoTotalCount.js";
 
 export function TodoApp($div) {
-    const $ul = $div.querySelector('#todo-list')
+  const $ul = $div.querySelector("#todo-list");
 
-    this.todoItems = [];
-    this.filter = 'all';
+  this.todoItems = [];
+  this.filter = "all";
 
-    this.todoInput = new TodoInput(this);
-    this.todoList = new TodoList($ul, this);
-    this.todoTotalCount = new TodoTotalCount( $div, this );
+  this.todoInput = new TodoInput(this);
+  this.todoList = new TodoList($ul, this);
+  this.todoTotalCount = new TodoTotalCount($div, this);
 
-    this.setState = updatedItems => {
-      this.todoItems = updatedItems;
-      this.TodoList.setState(this.todoItems);
+  this.setState = (updatedItems) => {
+    this.todoItems = updatedItems;
+    this.TodoList.setState(this.todoItems);
+  };
+
+  this.saveItem = (item) => {
+    this.todoItems.push(item);
+    this.filterTodo(this.filter);
+  };
+
+  this.complete = (todoItem) => {
+    this.todoItems
+      .filter((item) => item.todoItem === todoItem)
+      .map((item) => (item.completed = !item.completed));
+
+    this.filterTodo(this.filter);
+  };
+
+  this.delete = (todoItem) => {
+    const index = this.todoItems.findIndex(
+      (item) => item.todoItem === todoItem
+    );
+    this.todoItems.splice(index, 1);
+    this.filterTodo(this.filter);
+  };
+
+  this.update = (id, todoItem) => {
+    const index = this.todoItems.findIndex((item) => item.todoItem === id);
+    this.todoItems[index].todoItem = todoItem;
+    this.todoList.render(this.todoItems);
+  };
+
+  this.filterTodo = (completeStatus) => {
+    this.filter = completeStatus;
+
+    const status = {
+      all: () => this.todoItems,
+      active: () => this.todoItems.filter((item) => !item.completed),
+      completed: () => this.todoItems.filter((item) => item.completed),
     };
+    const filterTodoItems = status[this.filter]();
 
-    this.saveItem = (item) => {
-      this.todoItems.push(item)
-      this.filterTodo(this.filter);
-    }
-
-    this.complete = (todoItem) => {
-      
-      this.todoItems.filter(item => item.todoItem === todoItem)
-                     .map(item => item.completed = !item.completed)
-
-      this.filterTodo(this.filter);
-    }
-
-    this.delete = (todoItem) => {
-      const index = this.todoItems.findIndex(item => item.todoItem === todoItem);
-      this.todoItems.splice(index, 1);
-      this.filterTodo(this.filter);
-    }
-
-    this.update = (id, todoItem) =>{
-      const index = this.todoItems.findIndex(item => item.todoItem === id);
-      this.todoItems[index].todoItem = todoItem;
-      this.todoList.render(this.todoItems)
-    }
-  
-      this.filterTodo = (completeStatus) =>{
-        this.filter = completeStatus;
-      
-        const status = {
-          all : () => this.todoItems,
-          active : () => this.todoItems.filter(item => !item.completed),
-          completed : () => this.todoItems.filter(item => item.completed)
-        }
-        const filterTodoItems = status[this.filter]();
-
-        this.todoList.render(filterTodoItems);
-        this.todoTotalCount.setState(filterTodoItems, this.filter);
-    }
+    this.todoList.render(filterTodoItems);
+    this.todoTotalCount.setState(filterTodoItems, this.filter);
+  };
 }
-  
-

--- a/component/TodoInput.js
+++ b/component/TodoInput.js
@@ -2,14 +2,15 @@
 export function TodoInput( context ) {
     const $todoInput = document.querySelector("#new-todo-title");
   
-    $todoInput.addEventListener("keypress", event => this.addTodoItem(event));
   
     this.addTodoItem = event => {
       const $newTodoTarget = event.target;
-      if(event.keyCode === 13){
+      if(event.key === 'Enter'){
          context.saveItem({todoItem: $newTodoTarget.value, completed: false});
          $todoInput.value = '';
       }
     };
+    
+    $todoInput.addEventListener("keypress", this.addTodoItem);
   }
   

--- a/component/TodoInput.js
+++ b/component/TodoInput.js
@@ -1,0 +1,15 @@
+
+export function TodoInput( context ) {
+    const $todoInput = document.querySelector("#new-todo-title");
+  
+    $todoInput.addEventListener("keypress", event => this.addTodoItem(event));
+  
+    this.addTodoItem = event => {
+      const $newTodoTarget = event.target;
+      if(event.keyCode === 13){
+         context.saveItem({todoItem: $newTodoTarget.value, completed: false});
+         $todoInput.value = '';
+      }
+    };
+  }
+  

--- a/component/TodoInput.js
+++ b/component/TodoInput.js
@@ -1,16 +1,13 @@
+export function TodoInput(context) {
+  const $todoInput = document.querySelector("#new-todo-title");
 
-export function TodoInput( context ) {
-    const $todoInput = document.querySelector("#new-todo-title");
-  
-  
-    this.addTodoItem = event => {
-      const $newTodoTarget = event.target;
-      if(event.key === 'Enter'){
-         context.saveItem({todoItem: $newTodoTarget.value, completed: false});
-         $todoInput.value = '';
-      }
-    };
-    
-    $todoInput.addEventListener("keypress", this.addTodoItem);
-  }
-  
+  this.addTodoItem = (event) => {
+    const $newTodoTarget = event.target;
+    if (event.key === "Enter") {
+      context.saveItem({ todoItem: $newTodoTarget.value, completed: false });
+      $todoInput.value = "";
+    }
+  };
+
+  $todoInput.addEventListener("keypress", this.addTodoItem);
+}

--- a/component/TodoList.js
+++ b/component/TodoList.js
@@ -1,7 +1,7 @@
 export function TodoList($ul, context ) {
     this.todoItmes = [];
 
-    this.setState = updatedTodoItems => {
+    this.setState = (updatedTodoItems) => {
       this.todoItems = updatedTodoItems;
       this.render(this.todoItems);
     };

--- a/component/TodoList.js
+++ b/component/TodoList.js
@@ -22,6 +22,7 @@ export function TodoList($ul, context) {
 
     if (className.contains("toggle")) {
       this.complete(event.target.closest("li").id);
+      return;
     }
     if (className.contains("destroy")) {
       this.delete(event.target.closest("li").id);

--- a/component/TodoList.js
+++ b/component/TodoList.js
@@ -1,64 +1,64 @@
-export function TodoList($ul, context ) {
+export function TodoList($ul, context) {
+  this.setState = (updatedTodoItems) => {
+    this.render(updatedTodoItems);
+  };
 
-    this.setState = (updatedTodoItems) => {
-      this.render(updatedTodoItems);
+  this.complete = (todoItem) => context.complete(todoItem);
+  this.delete = (todoItem) => context.delete(todoItem);
+
+  this.update = (id, todoItem) => {
+    if (todoItem === null || todoItem === "") {
+      alert("빈값이 들어올 순 없습니다");
+      return;
     }
+    context.update(id, todoItem);
+  };
 
-    this.complete = (todoItem) => context.complete(todoItem)
-    this.delete = (todoItem) => context.delete(todoItem)
-    
-    
-    this.update = (id, todoItem) => {
-      if(todoItem === null || todoItem === ''){
-        alert('빈값이 들어올 순 없습니다');
-        return;
-      }
-      context.update(id, todoItem);
+  const onClickEditing = (event) =>
+    event.target.closest("li").classList.add("editing");
+
+  const onClickTodoItem = (event) => {
+    const className = event.target.classList;
+
+    if (className.contains("toggle")) {
+      this.complete(event.target.closest("li").id);
     }
-  
-
-    const onClickEditing = (event) => event.target.closest('li').classList.add('editing');
-    
-
-    const onClickTodoItem = (event) => {
-      const className = event.target.classList;
-
-      if(className.contains('toggle')){
-        this.complete(event.target.closest('li').id);
-      }
-      if(className.contains('destroy')){
-        this.delete(event.target.closest('li').id);
-      }
+    if (className.contains("destroy")) {
+      this.delete(event.target.closest("li").id);
     }
-    const onEdited = (event) => {
-      const updatedTodoItem = event.target.value;
-      const id = event.target.closest('li').id;
+  };
+  const onEdited = (event) => {
+    const updatedTodoItem = event.target.value;
+    const id = event.target.closest("li").id;
 
-      if (event.key === 'Enter') {
-        this.update(id, updatedTodoItem);
-        event.target.closest('li').classList.remove('editing');
-      } else if (event.key === 'Escape') {
-        event.target.closest('li').classList.remove('editing');
-      }
+    if (event.key === "Enter") {
+      this.update(id, updatedTodoItem);
+      event.target.closest("li").classList.remove("editing");
+    } else if (event.key === "Escape") {
+      event.target.closest("li").classList.remove("editing");
     }
-    
-    $ul.addEventListener('click', onClickTodoItem);
-    $ul.addEventListener('dblclick', onClickEditing);
-    $ul.addEventListener('keyup', onEdited);
+  };
 
-    this.render = items => {
-      $ul.innerHTML = items.map((item) => renderHTML(item))
-                           .join("");
-    };
-  }
+  $ul.addEventListener("click", onClickTodoItem);
+  $ul.addEventListener("dblclick", onClickEditing);
+  $ul.addEventListener("keyup", onEdited);
 
-  const renderHTML = (todoItem) => {
-   return `<li id=${todoItem.todoItem} class=${todoItem.completed ? "completed" : ""}>
+  this.render = (items) => {
+    $ul.innerHTML = items.map((item) => renderHTML(item)).join("");
+  };
+}
+
+const renderHTML = (todoItem) => {
+  return `<li id=${todoItem.todoItem} class=${
+    todoItem.completed ? "completed" : ""
+  }>
     <div class="view">
-      <input class="toggle" type="checkbox" ${todoItem.completed ? "checked" : ""}>
+      <input class="toggle" type="checkbox" ${
+        todoItem.completed ? "checked" : ""
+      }>
       <label class="label">${todoItem.todoItem}</label>
       <button class="destroy"></button>
     </div>
     <input class="edit">
-  </li>`
-}
+  </li>`;
+};

--- a/component/TodoList.js
+++ b/component/TodoList.js
@@ -1,0 +1,61 @@
+export function TodoList($ul, context ) {
+    this.todoItmes = [];
+
+    this.setState = updatedTodoItems => {
+      this.todoItems = updatedTodoItems;
+      this.render(this.todoItems);
+    };
+
+    this.complete = (todoItem) => {
+      context.complete(todoItem);
+    },
+    
+    this.delete = (todoItem) => {
+      context.delete(todoItem);
+    },
+    
+    this.update = (id, todoItem) => {
+      context.update(id, todoItem);
+    },
+  
+    $ul.addEventListener('click', event => {
+       if(event.target.className === 'toggle'){
+         this.complete(event.target.closest('li').id);
+       }
+       if(event.target.className === 'destroy'){
+         this.delete(event.target.closest('li').id);
+      }
+    })
+
+    $ul.addEventListener('dblclick', event => {
+        event.target.closest('li').classList.add('editing');
+    })
+
+    $ul.addEventListener('keydown', event => {
+      const updatedTodoItem = event.target.value;
+      const id = event.target.closest('li').id;
+      if (event.keyCode === 13) {;
+        this.update(id, updatedTodoItem);
+        event.target.closest('li').classList.remove('editing');
+      } else if (event.keyCode === 27) {
+        event.target.closest('li').classList.remove('editing');
+      }
+      
+    })    
+
+    this.render = items => {
+      $ul.innerHTML = items.map((item) => renderHTML(item))
+                           .join("");
+    };
+  }
+
+  const renderHTML = (todoItem) => {
+   return `<li id=${todoItem.todoItem} class=${todoItem.completed ? "completed" : ""}>
+    <div class="view">
+      <input class="toggle" type="checkbox" ${todoItem.completed ? "checked" : ""}>
+      <label class="label">${todoItem.todoItem}</label>
+      <button class="destroy"></button>
+    </div>
+    <input class="edit">
+  </li>`
+}

--- a/component/TodoList.js
+++ b/component/TodoList.js
@@ -1,47 +1,50 @@
 export function TodoList($ul, context ) {
-    this.todoItmes = [];
 
     this.setState = (updatedTodoItems) => {
-      this.todoItems = updatedTodoItems;
-      this.render(this.todoItems);
-    };
+      this.render(updatedTodoItems);
+    }
 
-    this.complete = (todoItem) => {
-      context.complete(todoItem);
-    },
+    this.complete = (todoItem) => context.complete(todoItem)
+    this.delete = (todoItem) => context.delete(todoItem)
     
-    this.delete = (todoItem) => {
-      context.delete(todoItem);
-    },
     
     this.update = (id, todoItem) => {
-      context.update(id, todoItem);
-    },
-  
-    $ul.addEventListener('click', event => {
-       if(event.target.className === 'toggle'){
-         this.complete(event.target.closest('li').id);
-       }
-       if(event.target.className === 'destroy'){
-         this.delete(event.target.closest('li').id);
+      if(todoItem === null || todoItem === ''){
+        alert('빈값이 들어올 순 없습니다');
+        return;
       }
-    })
+      context.update(id, todoItem);
+    }
+  
 
-    $ul.addEventListener('dblclick', event => {
-        event.target.closest('li').classList.add('editing');
-    })
+    const onClickEditing = (event) => event.target.closest('li').classList.add('editing');
+    
 
-    $ul.addEventListener('keydown', event => {
+    const onClickTodoItem = (event) => {
+      const className = event.target.classList;
+
+      if(className.contains('toggle')){
+        this.complete(event.target.closest('li').id);
+      }
+      if(className.contains('destroy')){
+        this.delete(event.target.closest('li').id);
+      }
+    }
+    const onEdited = (event) => {
       const updatedTodoItem = event.target.value;
       const id = event.target.closest('li').id;
-      if (event.keyCode === 13) {;
+
+      if (event.key === 'Enter') {
         this.update(id, updatedTodoItem);
         event.target.closest('li').classList.remove('editing');
-      } else if (event.keyCode === 27) {
+      } else if (event.key === 'Escape') {
         event.target.closest('li').classList.remove('editing');
       }
-      
-    })    
+    }
+    
+    $ul.addEventListener('click', onClickTodoItem);
+    $ul.addEventListener('dblclick', onClickEditing);
+    $ul.addEventListener('keyup', onEdited);
 
     this.render = items => {
       $ul.innerHTML = items.map((item) => renderHTML(item))

--- a/component/TodoTotalCount.js
+++ b/component/TodoTotalCount.js
@@ -1,30 +1,31 @@
+export function TodoTotalCount($div, context) {
+  const $count = document.querySelector(".todo-count > strong");
+  const $filter = $div.querySelector(".filters");
 
-export function TodoTotalCount( $div, context ){
-    const $count = document.querySelector('.todo-count > strong');
-    const $filter = $div.querySelector('.filters');
+  this.setState = (todoItems, filter) => {
+    this.render(todoItems, filter);
+  };
 
+  this.render = (todoItems, filter) => {
+    $count.innerText = todoItems.length;
+    $filter.innerHTML = renderHTML(filter);
+  };
 
-    this.setState = (todoItems, filter) => {
-        this.render(todoItems, filter);
-    };
-    
-    this.render = (todoItems, filter) => {
-        $count.innerText = todoItems.length;
-        $filter.innerHTML = renderHTML(filter);
-    };
+  $filter.addEventListener("click", (e) =>
+    context.filterTodo(e.target.classList.value)
+  );
 
-    $filter.addEventListener('click', e => context.filterTodo(e.target.classList.value));
-
-    const renderHTML = (filter) => {
-        return `<li>
-                    <a class="${filter === '전체보기' ? 'all selected' : 'all'}" href="#">전체보기</a>
+  const renderHTML = (filter) => {
+    return `<li>
+                    <a class="${filter === "전체보기" ? "all selected" : "all"}" href="#">전체보기</a>
                 </li>
                 <li>
-                    <a class="${filter === '해야할 일' ? 'active selected' : 'active'}" href="#active">해야할 일</a>
+                    <a class="${filter === "해야할 일" ? "active selected" : "active"}" href="#active">해야할 일</a>
                 </li>
                 <li>
-                    <a class="${filter === '완료한 일'? 'completed selected' : 'completed'}" href="#completed">완료한 일</a>
-                </li>`
-    }
-
+                    <a class="${filter === "완료한 일"
+                        ? "completed selected"
+                        : "completed" }" href="#completed">완료한 일</a>
+                </li>`;
+  };
 }

--- a/component/TodoTotalCount.js
+++ b/component/TodoTotalCount.js
@@ -4,29 +4,26 @@ export function TodoTotalCount( $div, context ){
     const $filter = $div.querySelector('.filters');
 
 
-    this.setState = (todoItems) => {
-        this.render(todoItems);
+    this.setState = (todoItems, filter) => {
+        this.render(todoItems, filter);
     };
     
-    this.render = (todoItems) => {
+    this.render = (todoItems, filter) => {
         $count.innerText = todoItems.length;
-        $filter.innerHTML = renderHTML();
+        $filter.innerHTML = renderHTML(filter);
     };
 
-    $filter.addEventListener('click', e => {
-        const completeState = e.target.innerText;
-        context.filterTodo(completeState);
-    });
+    $filter.addEventListener('click', e => context.filterTodo(e.target.classList.value));
 
-    const renderHTML = () => {
+    const renderHTML = (filter) => {
         return `<li>
-                    <a class="all selected" href="/#">전체보기</a>
+                    <a class="${filter === '전체보기' ? 'all selected' : 'all'}" href="#">전체보기</a>
                 </li>
                 <li>
-                    <a class="active" href="#active">해야할 일</a>
+                    <a class="${filter === '해야할 일' ? 'active selected' : 'active'}" href="#active">해야할 일</a>
                 </li>
                 <li>
-                    <a class="completed" href="#completed">완료한 일</a>
+                    <a class="${filter === '완료한 일'? 'completed selected' : 'completed'}" href="#completed">완료한 일</a>
                 </li>`
     }
 

--- a/component/TodoTotalCount.js
+++ b/component/TodoTotalCount.js
@@ -1,0 +1,35 @@
+
+export function TodoTotalCount( $div, context ){
+    const $count = document.querySelector('.todo-count > strong');
+    const $filter = $div.querySelector('.filters');
+
+    this.todoItems = [];
+
+    this.setState = updatedTodoItems => {
+        this.todoItems = updatedTodoItems;
+        this.render(this.todoItems);
+    };
+    
+    this.render = () => {
+        $count.innerText = this.todoItems.length;
+        $filter.innerHTML = renderHTML();
+    };
+
+    $filter.addEventListener('click', e => {
+        const completeState = e.target.innerText;
+        context.filterTodo(completeState);
+    });
+
+    const renderHTML = () => {
+        return `<li>
+                    <a class="all selected" href="/#">전체보기</a>
+                </li>
+                <li>
+                    <a class="active" href="#active">해야할 일</a>
+                </li>
+                <li>
+                    <a class="completed" href="#completed">완료한 일</a>
+                </li>`
+    }
+
+}

--- a/component/TodoTotalCount.js
+++ b/component/TodoTotalCount.js
@@ -3,15 +3,13 @@ export function TodoTotalCount( $div, context ){
     const $count = document.querySelector('.todo-count > strong');
     const $filter = $div.querySelector('.filters');
 
-    this.todoItems = [];
 
-    this.setState = updatedTodoItems => {
-        this.todoItems = updatedTodoItems;
-        this.render(this.todoItems);
+    this.setState = (todoItems) => {
+        this.render(todoItems);
     };
     
-    this.render = () => {
-        $count.innerText = this.todoItems.length;
+    this.render = (todoItems) => {
+        $count.innerText = todoItems.length;
         $filter.innerHTML = renderHTML();
     };
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>이벤트 - TODOS</title>
     <link rel="stylesheet" href="css/style.css" />
-  </head>
+ </head>
   <body>
     <div class="todoapp">
       <h1>TODOS</h1>
@@ -22,7 +22,7 @@
           <span class="todo-count">총 <strong>0</strong> 개</span>
           <ul class="filters">
             <li>
-              <a class="all selected" href="/#">전체보기</a>
+              <a class="all selected" href="#">전체보기</a>
             </li>
             <li>
               <a class="active" href="#active">해야할 일</a>
@@ -34,5 +34,6 @@
         </div>
       </main>
     </div>
+    <script type="module" src="app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 🎯 요구사항

- [x] todo list에 todoItem을 키보드로 입력하여 추가하기
- [x] todo list의 체크박스를 클릭하여 complete 상태로 변경. (li tag 에 completed class 추가, input 태그에 checked 속성 추가)
- [x] todo list의 x버튼을 이용해서 해당 엘리먼트를 삭제
- [x] todo list를 더블클릭했을 때 input 모드로 변경. (li tag 에 editing class 추가) 단 이때 수정을 완료하지 않은 상태에서 esc키를 누르면 수정되지 않은 채로 다시 view 모드로 복귀
- [x] todo list의 item갯수를 count한 갯수를 리스트의 하단에 보여주기
- [x] todo list의 상태값을 확인하여, 해야할 일과, 완료한 일을 클릭하면 해당 상태의 아이템만 보여주기

## 🎯🎯 심화 요구사항

- [x] localStorage에 데이터를 저장하여, TodoItem의 CRUD를 반영하기. 따라서 새로고침하여도 저장된 데이터를 확인할 수 있어야 함

## [코멘트]
 - 상태관리와 프런트엔드는 아직 익숙하지가 않아서 @skid901 님 소스코드 참고해서 작성했습니다. 덕분에 정말 많은 도움됐습니다. 감사합니다.
 - 처음에는 한 페이지내에서 queryselector 잡고 이벤트를 등록하는 반복적인 작업을 했었는데 이렇게 컴포넌트별로 분리하고 상태관리를 하니깐 생각보다 update와 delete 기능구현할 때 데이터 기반으로 접근하다보니 편하게 구현할 수 있어서 굉장히 좋았습니다.  
- 아직 많이 부족하지만, 리뷰요청부탁드립니다 : ) 
